### PR TITLE
Fix async unlink error

### DIFF
--- a/src/process-streams.js
+++ b/src/process-streams.js
@@ -34,14 +34,14 @@ function createStream (tmpIn, tmpOut, callback) {
             if (tmpIn) {
               fs.exists(tmpIn, function (exists) {
                 if (exists) {
-                  fs.unlink(tmpIn)
+                  fs.unlink(tmpIn, function () {})
                 }
               })
             }
             if (tmpOut) {
               fs.exists(tmpOut, function (exists) {
                 if (exists) {
-                  fs.unlink(tmpOut)
+                  fs.unlink(tmpOut, function () {})
                 }
               })
             }
@@ -49,7 +49,7 @@ function createStream (tmpIn, tmpOut, callback) {
           }
           // tmpFile is not needed anymore
           if (tmpIn) {
-            fs.unlink(tmpIn)
+            fs.unlink(tmpIn, function () {})
           }
           if (tmpOut) {
             fs.exists(tmpOut, function (exists) {
@@ -57,7 +57,7 @@ function createStream (tmpIn, tmpOut, callback) {
                 var out = fs.createReadStream(tmpOut)
                 out.pipe(outgoing)
                 out.on('end', function () {
-                  fs.unlink(tmpOut)
+                  fs.unlink(tmpOut, function () {})
                 })
               } else {
                 result.emit('error', new Error('Child process has not created the output-temp file'))


### PR DESCRIPTION
Issue type: **Bug**
Importance: **Non-critical**

Since `fs.unlink` is [an asynchronous function](https://nodejs.org/api/fs.html#fs_fs_unlink_path_callback), it requires a callback to avoid deprecation errors. Noop functions added. Another solution could be using the `fs.unlinkSync` function instead, but it's probably better to keep the async version.